### PR TITLE
Fixed signed and unsigned int comparison (line 52)

### DIFF
--- a/rpc.c
+++ b/rpc.c
@@ -49,7 +49,7 @@ extract_string_from_map(msgpack_object *obj, const char* key)
 		return 0;
 	}
 
-	for (int ii = 0; ii < obj->via.map.size; ++ii)
+	for (unsigned int ii = 0; ii < obj->via.map.size; ++ii)
 	{
 		msgpack_object currentKey = obj->via.map.ptr[ii].key;
 		msgpack_object currentVal = obj->via.map.ptr[ii].val;


### PR DESCRIPTION
There was an error generated when compiling on 64-bit GNU/Linux  

> error: comparison between signed and unsigned integer expressions
